### PR TITLE
day 18 swagger api docs

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "express": "^5.1.0",
     "joi": "^17.13.3",
     "jsonwebtoken": "^9.0.2",
-    "mongoose": "^8.15.1"
+    "mongoose": "^8.15.1",
+    "swagger-ui-express": "^5.0.1"
   },
   "devDependencies": {
     "nodemon": "^3.1.10"

--- a/server.js
+++ b/server.js
@@ -1,5 +1,7 @@
 const express = require("express");
 const dotenv = require("dotenv");
+const swaggerUi = require('swagger-ui-express');
+const swaggerDocument = require('./swagger.json');
 const connectDB = require("./config/connectDB");
 const authRoutes = require("./routes/authRoutes");
 const taskRoutes = require('./routes/taskRoutes');
@@ -11,6 +13,7 @@ const app = express();
 
 connectDB();
 app.use(express.json());
+app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(swaggerDocument));
 
 app.get("/", (req, res) => {
   res.status(200).send("Server is running");

--- a/swagger.json
+++ b/swagger.json
@@ -1,0 +1,152 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Task Management API",
+    "version": "1.0.0",
+    "description": "API documentation for Task Management project"
+  },
+  "servers": [
+    {
+      "url": "http://localhost:3300",
+      "description": "Local server"
+    }
+  ],
+  "paths": {
+    "/api/tasks": {
+      "get": {
+        "summary": "Get all tasks",
+        "tags": ["Tasks"],
+        "responses": {
+          "200": {
+            "description": "List of tasks"
+          }
+        }
+      },
+      "post": {
+        "summary": "Create a new task",
+        "tags": ["Tasks"],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "title": { "type": "string" },
+                  "status": { "type": "string" },
+                  "dueDate": { "type": "string", "format": "date" }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Task created"
+          }
+        }
+      }
+    },
+    "/api/tasks/{id}": {
+      "get": {
+        "summary": "Get task by ID",
+        "tags": ["Tasks"],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": { "description": "Task found" },
+          "404": { "description": "Task not found" }
+        }
+      },
+      "put": {
+        "summary": "Update task",
+        "tags": ["Tasks"],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": { "description": "Task updated" },
+          "404": { "description": "Task not found" }
+        }
+      },
+      "delete": {
+        "summary": "Delete task",
+        "tags": ["Tasks"],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": { "description": "Task deleted" },
+          "404": { "description": "Task not found" }
+        }
+      }
+    },
+    "/api/auth/register": {
+      "post": {
+        "summary": "Register a new user",
+        "tags": ["Auth"],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": { "type": "string" },
+                  "email": { "type": "string" },
+                  "password": { "type": "string" }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "User registered"
+          }
+        }
+      }
+    },
+    "/api/auth/login": {
+      "post": {
+        "summary": "Login a user",
+        "tags": ["Auth"],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "email": { "type": "string" },
+                  "password": { "type": "string" }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "User logged in"
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## 📄 Day 18: API Documentation with Swagger

### ✅ Summary
This PR sets up Swagger documentation for the Task Management API. It provides a user-friendly interface to explore and test the available endpoints through a dedicated `/api-docs` route.

### 🔧 Key Updates
- Added `swagger-ui-express` to serve the API documentation.
- Created a `swagger.json` file containing all endpoint definitions.
- Integrated Swagger middleware in `app.js` for live documentation.

### 📁 New Files
```
├── swagger.json       # OpenAPI specification for documenting API routes
```

### 🚀 Features Documented
- **Task Routes**:
  - `GET /api/tasks` – Fetch all tasks
  - `POST /api/tasks` – Create a new task
  - `GET /api/tasks/:id` – Get task by ID
  - `PUT /api/tasks/:id` – Update a task
  - `DELETE /api/tasks/:id` – Delete a task
- **Auth Routes**:
  - `POST /api/auth/register` – Register a new user
  - `POST /api/auth/login` – Login a user

### 🔗 How to Access Docs
Once the server is running, navigate to:
`http://localhost:3300/api-docs`  
This will open the Swagger UI for testing and exploring your API.
